### PR TITLE
Added additional link types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Grav Page Inject Plugin
 
-`Page Inject` is a powerful [Grav][grav] Plugin that lets you inject entire pages or page content into other pages using simple markdown syntax
+`Page Inject` is a powerful [Grav][grav] Plugin that lets you inject entire pages, page content or other markdown into a page using simple markdown syntax
 
 # Installation
 
@@ -48,7 +48,7 @@ page-inject:
 
 # Usage
 
-There are two ways to use this plugin in your markdown content:
+There are four ways to use this plugin in your markdown content:
 
 1. **Page Injection**
 
@@ -56,7 +56,7 @@ There are two ways to use this plugin in your markdown content:
     [plugin:page-inject](/route/to/page)
     ```
 
-    This approach includes an entire page rendered with the associated template.  This works best for modular page content or content that uses a specific template that provides appropriate styling that is intended to be part of other pages.  you can also pass an optional template name and use that template to render teh page (as long as you also provide the template in your theme):
+    This approach includes an entire page rendered with the associated template. This works best for modular page content or content that uses a specific template that provides apropriate styling that is intended to be part of other pages. You can also pass an optional template name and use that template to render the page (as long as you also provide the template in your theme):
 
     ```
     [plugin:page-inject](/route/to/page?template=custom-template)
@@ -68,6 +68,23 @@ There are two ways to use this plugin in your markdown content:
     [plugin:content-inject](/route/to/page)
     ```
 
-    Sometimes you just want the content of another page injected directly into your current page.  Use `content-inject` for this purpose.  The content is not rendered with the assoicated twig template, merely injected into the current page.
+    Sometimes you just want the content of another page injected directly into your current page.  Use `content-inject` for this purpose.  The content is not rendered with the associated Twig template, merely injected into the current page.
 
+3. **File Injection**
+
+    ```
+    [plugin:file-inject](/route/to/file)
+    ```
+
+    The plugin will look for the file starting at the Grav user directory. If the file exists it will inject it’s content. Just like with "page-inject", you can optionally use a custom template.
+
+1. **URL Injection**
+
+    ```
+    [plugin:url-inject](url)
+    ```
+
+    If the URL is valid the content of the file it points to is injected. The use of a custom template is supported.   
+    Injecting content from remote sites is relatively dangerous. You are advised to use the Twig `|escape` or `|striptags` filter in such a template.
+    
 [grav]: http://github.com/getgrav/grav

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ There are four ways to use this plugin in your markdown content:
     [plugin:page-inject](/route/to/page)
     ```
 
-    This approach includes an entire page rendered with the associated template. This works best for modular page content or content that uses a specific template that provides apropriate styling that is intended to be part of other pages. You can also pass an optional template name and use that template to render the page (as long as you also provide the template in your theme):
+    This approach includes an entire page rendered with the associated template. This works best for modular page content or content that uses a specific template that provides appropriate styling that is intended to be part of other pages. You can also pass an optional template name and use that template to render the page (as long as you also provide the template in your theme):
 
     ```
     [plugin:page-inject](/route/to/page?template=custom-template)

--- a/README.md
+++ b/README.md
@@ -76,15 +76,15 @@ There are four ways to use this plugin in your markdown content:
     [plugin:file-inject](/route/to/file)
     ```
 
-    The plugin will look for the file starting at the Grav user directory. If the file exists it will inject it’s content. Just like with "page-inject", you can optionally use a custom template.
+    The plugin will look for the file starting at the Grav user directory. If the file exists it will inject it’s content. Just like with "page-inject", you can optionally use a custom template. The markdown content of the file will be available in a Twig variable named `markdown`.
 
-1. **URL Injection**
+4. **URL Injection**
 
     ```
     [plugin:url-inject](url)
     ```
 
-    If the URL is valid the content of the file it points to is injected. The use of a custom template is supported.   
-    Injecting content from remote sites is relatively dangerous. You are advised to use the Twig `|escape` or `|striptags` filter in such a template.
+    If the URL is valid the content of the file it points to is injected. The use of a custom template is supported. You can use the Twig variable `markdown` to process the requested markdown.   
+    Note: Injecting content from remote sites is relatively dangerous. You are advised to use the Twig `|escape` or `|striptags` filter in such a template.
     
 [grav]: http://github.com/getgrav/grav

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ There are four ways to use this plugin in your markdown content:
     [plugin:page-inject](/route/to/page)
     ```
 
-    This approach includes an entire page rendered with the associated template. This works best for modular page content or content that uses a specific template that provides appropriate styling that is intended to be part of other pages. You can also pass an optional template name and use that template to render the page (as long as you also provide the template in your theme):
+    This approach includes an entire page rendered with the associated template. This works best for modular page content or content that uses a specific template that provides apropriate styling that is intended to be part of other pages. You can also pass an optional template name and use that template to render the page (as long as you also provide the template in your theme):
 
     ```
     [plugin:page-inject](/route/to/page?template=custom-template)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ There are four ways to use this plugin in your markdown content:
     [plugin:page-inject](/route/to/page)
     ```
 
-    This approach includes an entire page rendered with the associated template. This works best for modular page content or content that uses a specific template that provides appropriate styling that is intended to be part of other pages. You can also pass an optional template name and use that template to render the page (as long as you also provide the template in your theme):
+    This approach includes an entire page rendered with the associated template. This works best for modular page content or content that uses a specific template that provides appropriate styling that is intended to be part of other pages. The `/route/to/page` is the absolute page route from the site root. You can also pass an optional template name and use that template to render the page (as long as you also provide the template in your theme):
 
     ```
     [plugin:page-inject](/route/to/page?template=custom-template)

--- a/page-inject.php
+++ b/page-inject.php
@@ -77,6 +77,13 @@ class PageInjectPlugin extends Plugin
                     $user_path = $this->grav['locator']->findResource('user://');
                     if (file_exists($user_path . '/' . $page_path)) {
                         $replace = file_get_contents($user_path . '/' . $page_path);
+                        if ($template) {
+                            $replace = $this->grav['twig']->processTemplate($template, ['markdown' => $replace]);
+                        }
+
+                    } else {
+                        // replace with what you started with
+                        $replace = $matches[0];
                     }
 
                 } else {
@@ -86,7 +93,13 @@ class PageInjectPlugin extends Plugin
                         $headers = substr($headers[0], 9, 3);
                         if ($headers == "200") {
                             $replace = file_get_contents($page_path);
-                            $replace = $file;
+                            if ($template) {
+                                $replace = $this->grav['twig']->processTemplate($template, ['markdown' => $replace]);
+                            }
+                            
+                        } else {
+                            // replace with what you started with
+                            $replace = $matches[0];
                         }
 
                     } else {


### PR DESCRIPTION
This pull request contains two additional link types (`file-inject` and `url-inject`) by which markdown content can be injected in a page. The changes are a result of my own reply to the forum post ["Include .md file in default.md"](https://discourse.getgrav.org/t/include-md-file-in-default-md/12993) and the one given by Paul Hibbits.

I think all four link types still fit the plugin's title **Grav Page Inject Plugin** when you don't read it as "inject a page (into a page) but more like "inject (markdown) into a page".

It also "fixes" issues #19 and #21.