### PR TITLE
inject media

### DIFF
--- a/classes/shortcodes/PageInjectShortcode.php
+++ b/classes/shortcodes/PageInjectShortcode.php
@@ -18,5 +18,11 @@ class PageInjectShortcode extends Shortcode
             $path = $sc->getParameter('path') ?? $sc->getBbCode();
             return PageInjectPlugin::getInjectedPageContent('content-inject', $path, $this->shortcode->getPage());
         });
+
+        $this->shortcode->getRawHandlers()->add('html-inject', function(ShortcodeInterface $sc) {
+            $path = $sc->getParameter('path') ?? $sc->getBbCode();
+            return PageInjectPlugin::getInjectedPageContent('html-inject', $path, $this->shortcode->getPage());
+        });       
+        
     }
 }

--- a/page-inject.php
+++ b/page-inject.php
@@ -176,7 +176,7 @@ class PageInjectPlugin extends Plugin
         }
         preg_match('/(.*)\?template=(.*)|(.*)/i', $path, $template_matches);
 
-        $path = $template_matches[1] && $template_matches[2] ? $template_matches[1] : $path;
+        $path = $template_matches[1] && $template_matches[2] && $template_matches[3] ? $template_matches[1] : $path;
         $template = $template_matches[2];
         $replace = null;
         $page_path = Uri::convertUrl($page, $path, 'link', false, true);
@@ -184,7 +184,13 @@ class PageInjectPlugin extends Plugin
         $page_path = str_replace('/./', '/', $page_path);
 
         $inject = $pages->find($page_path);
-        if ($inject instanceof PageInterface && $inject->published()) {
+
+        if ($type == 'html-inject') {
+            if (file_exists($page->getMediaFolder() . '/' . $path)) {
+                $replace = file_get_contents($page->getMediaFolder() . '/' . $path);
+            }
+        }
+        else if ($inject instanceof PageInterface && $inject->published()) {
             // Force HTML to avoid issues with News Feeds
             $inject->templateFormat('html');
             if ($type == 'page-inject') {
@@ -248,7 +254,7 @@ class PageInjectPlugin extends Plugin
 
     protected function parseInjectLinks($content, $function)
     {
-        $regex = '/\[plugin:(content-inject|page-inject)\]\((.*)\)/i';
+        $regex = '/\[plugin:(content-inject|page-inject|html-inject)\]\((.*)\)/i';
         return preg_replace_callback($regex, $function, $content);
     }
 


### PR DESCRIPTION
hi,

i'm not a php or grav expert but i managed to modify the plugin so it can include files attached as page media.

i need this to include plotly.js plots directly without using iframes.

<img width="617" alt="image" src="https://user-images.githubusercontent.com/4736160/189186890-fbe922d0-d834-4a8a-81ef-bcf728f041f4.png">

i don't know if the modifications broke something. but if you want to, you should easily be able to include this functionality  to your plugin the right way.

kind regards
